### PR TITLE
[CI] GitHub Actions workflow for automatic deployment to GCP Cloud Run

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,32 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflows for automating various tasks in the pdf-edition-v2 project.
+
+## deploy-api.yml
+
+This workflow automatically deploys the API to Google Cloud Run when changes are merged to the main branch and there are changes in the `api` directory.
+
+### Workflow Details
+
+- **Trigger**: Push to the `main` branch with changes in the `api` directory
+- **Actions**:
+  1. Checkout the repository
+  2. Set up Google Cloud SDK
+  3. Authenticate to Google Cloud using Workload Identity Federation
+  4. Set up Docker Buildx
+  5. Configure Docker for GCP Artifact Registry
+  6. Build and push the Docker image using the Makefile
+  7. Deploy to Cloud Run using the Makefile
+
+### Required Secrets
+
+The following secrets need to be configured in the GitHub repository settings:
+
+- `WORKLOAD_IDENTITY_PROVIDER`: The Workload Identity Provider for GCP authentication
+- `SERVICE_ACCOUNT`: The GCP service account email for deployment
+
+### Setup Instructions
+
+1. Create a service account in GCP with the necessary permissions for Artifact Registry and Cloud Run
+2. Set up Workload Identity Federation in GCP
+3. Add the required secrets to the GitHub repository settings

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,47 @@
+name: Deploy API to GCP Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'api/**'
+
+jobs:
+  deploy:
+    name: Build and Deploy API
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      id-token: write # Required for GCP authentication
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: pdf-edition-v2
+      
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Configure Docker for GCP Artifact Registry
+        run: |
+          gcloud auth configure-docker asia-northeast1-docker.pkg.dev
+      
+      - name: Build and Push Docker image
+        working-directory: ./api
+        run: make docker-push
+      
+      - name: Deploy to Cloud Run
+        working-directory: ./api
+        run: make deploy


### PR DESCRIPTION
## 概要
Issue #36 の対応として、GitHub Actions ワークフローを追加しました。このワークフローは、`main` ブランチにマージされた際に、`api` ディレクトリ内の変更があった場合に自動的に GCP Cloud Run にデプロイを行います。

## 変更内容
- `.github/workflows/deploy-api.yml` ファイルを作成し、デプロイワークフローを設定
- `.github/workflows/README.md` ファイルを作成し、ワークフローの説明を追加

## 動作の流れ
1. `main` ブランチへのプッシュで、`api` ディレクトリ内に変更がある場合にワークフローが起動
2. Google Cloud SDK のセットアップと認証
3. Docker イメージのビルドとプッシュ（`make docker-push` コマンドを使用）
4. Cloud Run へのデプロイ（`make deploy` コマンドを使用）

## 必要な設定
このワークフローを動作させるためには、以下のシークレットを GitHub リポジトリの設定に追加する必要があります：
- `WORKLOAD_IDENTITY_PROVIDER`: GCP 認証用のワークロード ID プロバイダー
- `SERVICE_ACCOUNT`: デプロイ用の GCP サービスアカウントメール

Closes #36