### PR TITLE
[frontend] 結合後のファイル名を入力出来るようにする

### DIFF
--- a/frontend/src/api/pdfApi.ts
+++ b/frontend/src/api/pdfApi.ts
@@ -3,15 +3,19 @@ import { requestPost } from "@/api/request";
 const MERGE_PDF_ENDPOINT = "/api/merge-pdf";
 const SPLIT_PDF_ENDPOINT = "/api/split-pdf";
 
-export const mergePdf = async (files: File[]) => {
+export const mergePdf = async (files: File[], filename: string = "merged.pdf") => {
   const formData = new FormData();
   files.forEach((file) => formData.append("files", file));
   const blob = await requestPost<Blob>(MERGE_PDF_ENDPOINT, formData, {
     responseType: "blob",
   });
+  
+  // ファイル名に.pdfの拡張子がない場合は追加
+  const downloadFilename = filename.endsWith('.pdf') ? filename : `${filename}.pdf`;
+  
   const link = document.createElement("a");
   link.href = URL.createObjectURL(blob);
-  link.download = "merged.pdf";
+  link.download = downloadFilename;
   link.click();
   // メモリリーク防止にURLを解放
   URL.revokeObjectURL(link.href);

--- a/frontend/src/api/pdfApi.ts
+++ b/frontend/src/api/pdfApi.ts
@@ -3,16 +3,21 @@ import { requestPost } from "@/api/request";
 const MERGE_PDF_ENDPOINT = "/api/merge-pdf";
 const SPLIT_PDF_ENDPOINT = "/api/split-pdf";
 
-export const mergePdf = async (files: File[], filename: string = "merged.pdf") => {
+export const mergePdf = async (
+  files: File[],
+  filename: string = "merged.pdf"
+) => {
   const formData = new FormData();
   files.forEach((file) => formData.append("files", file));
   const blob = await requestPost<Blob>(MERGE_PDF_ENDPOINT, formData, {
     responseType: "blob",
   });
-  
+
   // ファイル名に.pdfの拡張子がない場合は追加
-  const downloadFilename = filename.endsWith('.pdf') ? filename : `${filename}.pdf`;
-  
+  const downloadFilename = filename.toLowerCase().endsWith(".pdf")
+    ? filename
+    : `${filename}.pdf`;
+
   const link = document.createElement("a");
   link.href = URL.createObjectURL(blob);
   link.download = downloadFilename;

--- a/frontend/src/app/merge-pdf/page.tsx
+++ b/frontend/src/app/merge-pdf/page.tsx
@@ -109,7 +109,7 @@ const MergePdf = () => {
                   <Input
                     value={filename}
                     onChange={setFilename}
-                    placeholder="merged"
+                    placeholder="merged.pdf"
                     disabled={loading}
                   />
                   <p className="text-xs text-slate-400">

--- a/frontend/src/app/merge-pdf/page.tsx
+++ b/frontend/src/app/merge-pdf/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import UploadFile from "@/components/common/uploadFile";
 import { mergePdf } from "@/api/pdfApi";
 import Button from "@/components/common/button";
+import Input from "@/components/common/input";
 import SortableFileItemList from "@/app/merge-pdf/_components/sortableFileItemList";
 import { v4 as uuidv4 } from "uuid";
 import type { FileItem } from "@/app/merge-pdf/types";
@@ -13,6 +14,7 @@ const MergePdf = () => {
   const [fileItems, setFileItems] = useState<FileItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [filename, setFilename] = useState("");
   console.log(fileItems);
 
   const handleUpload = (uploadedFiles: File[]) => {
@@ -32,12 +34,14 @@ const MergePdf = () => {
     setLoading(true);
     try {
       const files = fileItems.map((item) => item.file);
-      await mergePdf(files);
+      const outputFilename = filename.trim() || "merged";
+      await mergePdf(files, outputFilename);
     } catch {
       setError("PDF 結合に失敗しました");
     } finally {
       setLoading(false);
       setFileItems([]);
+      setFilename("");
     }
   };
 
@@ -94,6 +98,26 @@ const MergePdf = () => {
                 </div>
               )}
             </div>
+
+            {/* ファイル名入力エリア */}
+            {fileItems.length > 0 && (
+              <div className="mb-6 border-t border-slate-300/20 pt-6">
+                <div className="flex flex-col gap-3">
+                  <label className="text-sm font-medium text-white">
+                    結合後のファイル名
+                  </label>
+                  <Input
+                    value={filename}
+                    onChange={setFilename}
+                    placeholder="merged"
+                    disabled={loading}
+                  />
+                  <p className="text-xs text-slate-400">
+                    ファイル名を入力してください（.pdfは自動で追加されます）
+                  </p>
+                </div>
+              </div>
+            )}
 
             {/* 実行ボタンエリア */}
             <div className="border-t border-slate-300/20 pt-6">

--- a/frontend/src/app/merge-pdf/page.tsx
+++ b/frontend/src/app/merge-pdf/page.tsx
@@ -15,8 +15,6 @@ const MergePdf = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [filename, setFilename] = useState("");
-  console.log(fileItems);
-
   const handleUpload = (uploadedFiles: File[]) => {
     const wrappedFiles: FileItem[] = uploadedFiles.map((file) => ({
       uid: uuidv4(),

--- a/frontend/src/components/common/input.tsx
+++ b/frontend/src/components/common/input.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+interface InputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+const Input: React.FC<InputProps> = ({
+  value,
+  onChange,
+  placeholder,
+  className = "",
+  disabled = false,
+}) => {
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={`w-full rounded-lg border border-slate-300/50 bg-white/10 px-4 py-3 text-white placeholder-slate-400 backdrop-blur-sm transition-all duration-200 focus:border-blue-400 focus:bg-white/20 focus:outline-none focus:ring-2 focus:ring-blue-400/50 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+    />
+  );
+};
+
+export default Input;

--- a/frontend/src/components/common/input.tsx
+++ b/frontend/src/components/common/input.tsx
@@ -22,7 +22,7 @@ const Input: React.FC<InputProps> = ({
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
       disabled={disabled}
-      className={`w-full rounded-lg border border-slate-300/50 bg-white/10 px-4 py-3 text-white placeholder-slate-400 backdrop-blur-sm transition-all duration-200 focus:border-blue-400 focus:bg-white/20 focus:outline-none focus:ring-2 focus:ring-blue-400/50 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+      className={`w-full rounded-lg border border-slate-300/50 bg-white/10 px-4 py-3 font-semibold text-white placeholder-slate-400 backdrop-blur-sm transition-all duration-200 focus:border-blue-400 focus:bg-white/15 focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
     />
   );
 };


### PR DESCRIPTION
## 概要
Issue #22 の対応として、PDF結合時にユーザーが任意のファイル名を指定できる機能を実装しました。

## 変更内容

### 新機能
- **ファイル名入力フィールドの追加**: PDF結合ページにファイル名を入力するためのテキストフィールドを追加
- **動的表示**: ファイルがアップロードされた時のみファイル名入力フィールドが表示される
- **自動拡張子追加**: `.pdf`拡張子がない場合は自動で追加される
- **デフォルト値**: 入力が空の場合は`merged`がデフォルト値として使用される

### 技術的変更
- **新しいInputコンポーネント**: 再利用可能なInputコンポーネントを`src/components/common/input.tsx`に作成
- **API関数の拡張**: `mergePdf`関数にファイル名パラメータを追加（デフォルト値: "merged.pdf"）
- **状態管理**: ファイル名の状態管理を追加
- **UI/UX改善**: ファイル名入力エリアを適切な位置に配置し、説明テキストを追加

## ファイル変更
- `frontend/src/api/pdfApi.ts`: `mergePdf`関数にファイル名パラメータを追加
- `frontend/src/app/merge-pdf/page.tsx`: ファイル名入力フィールドとロジックを追加
- `frontend/src/components/common/input.tsx`: 新しいInputコンポーネントを作成

## 動作確認
- ✅ ファイルアップロード前はファイル名入力フィールドが非表示
- ✅ ファイルアップロード後にファイル名入力フィールドが表示
- ✅ 空の入力値の場合はデフォルト値"merged"が使用される
- ✅ `.pdf`拡張子の自動追加機能が動作
- ✅ 処理完了後にファイル名フィールドがリセットされる

## UI/UX
- ファイル名入力フィールドは、ファイル一覧と実行ボタンの間に配置
- プレースホルダーとして"merged"を表示
- 説明テキストで拡張子が自動追加されることを明示
- 処理中は入力フィールドが無効化される

Fixes #22

@kikudesuyo can click here to [continue refining the PR](https://app.all-hands.dev/conversations/54bf2735d63e486ab391dbd5cb3ff233)